### PR TITLE
Fly masters fix.

### DIFF
--- a/updates_02/133_gossip_menu_option.sql
+++ b/updates_02/133_gossip_menu_option.sql
@@ -1,0 +1,19 @@
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=6944 AND `id`=0; -- general fly master menu (70 npc's use it.)
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=4342 AND `id`=0; -- Doras <Wind Rider Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=4358 AND `id`=0; -- Thorgrum Borrelson <Gryphon Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=4106 AND `id`=0; -- Thor <Gryphon Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=6563 AND `id`=0; -- Cloud Skydancer <Hippogryph Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=4106 AND `id`=1; -- Thor <Gryphon Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=4360 AND `id`=0; -- Gryth Thurden <Gryphon Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=4323 AND `id`=0; -- Devrak <Wind Rider Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=5968 AND `id`=0; -- Grisha <Wind Rider Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=12460 AND `id`=0; -- Bragok <Flight Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=11684 AND `id`=0; -- Urda <Wind Rider Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=12236 AND `id`=0; -- Khaelyn Steelwing <Gryphon Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=12462 AND `id`=0; -- Ginny Goodwin <Flight Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=12454 AND `id`=0; -- Bibilfaz Featherwhistle <Gryphon Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=12032 AND `id`=0; -- Janice Myers <Flight Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=11791 AND `id`=0; -- Robert Rhodes <Gryphon Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=8095 AND `id`=0; -- Runetog Wildhammer <Gryphon Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=10510 AND `id`=0; -- Thraka <Wind Rider Master>
+UPDATE `gossip_menu_option` SET `option_id`=4,`npc_option_npcflag`=8192 WHERE `menu_id`=10500 AND `id`=0; -- Andruk <Wind Rider Master>


### PR DESCRIPTION
Many fly masters are also gossi, quest givers etc. and use gossip menu options in order to function as fly masters. Fixed some of the options id's and flags for these menu's that enabled many fly masters.
