### PR TITLE
Fix merge_updates_windows.bat

### DIFF
--- a/merge_updates_windows.bat
+++ b/merge_updates_windows.bat
@@ -1,1 +1,1 @@
-copy /a updates_02\*.sql world_updates.sql
+copy /a updates_02\*.sql /b world_updates.sql


### PR DESCRIPTION
Prevent the end-of-file character for Heidi to run without an error message.
